### PR TITLE
Add Form code to output

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,5 +9,6 @@ RSForm! Helper also generates PHP code to insert and update the form data in you
 
 RSForm! Helper was written by René Kreijveld and is provided free of charge, without warranties. Questions, remarks, improvements? Feel free to contact me at http://about.me/renekreijveld
 
-January 29th: Remco Janssen
+January 29th: Remco Janssen:
+
 I've added a bit of code to this marvelous component to generate the HTML used in the form display (front-end) in Joomla. It simply creates a DIV structured layout with the classes you provide in the settings.

--- a/README.md
+++ b/README.md
@@ -8,3 +8,6 @@ RSForm! Helper then generates a table with all the fields nicely formatted in tw
 RSForm! Helper also generates PHP code to insert and update the form data in your own database tables.
 
 RSForm! Helper was written by René Kreijveld and is provided free of charge, without warranties. Questions, remarks, improvements? Feel free to contact me at http://about.me/renekreijveld
+
+January 29th: Remco Janssen
+I've added a bit of code to this marvelous component to generate the HTML used in the form display (front-end) in Joomla. It simply creates a DIV structured layout with the classes you provide in the settings.

--- a/administrator/views/formselects/tmpl/default.php
+++ b/administrator/views/formselects/tmpl/default.php
@@ -163,7 +163,7 @@ if ($tdstylev!='') $tdstylev = " style=\"$tdstylev\"";
 		</div>
 		<div class="control-group tdcsscaption">
 			<label class="control-label">
-				<a class="hasTooltip nolink" title="CSS code to be applied to the column that displays the form field <em>caption</em>." data-toggle="tooltip" href="#">TD css caption <span class="icon-info"></span></a><br/>
+				<a class="hasTooltip nolink" title="CSS code to be applied to the column that displays the form field <em>caption</em>." data-toggle="tooltip" href="#">TD/DIV css caption <span class="icon-info"></span></a><br/>
 			</label>
 			<div class="controls">
 				<input name="tdstylec" type="text" id="tdstylec" class="input-xlarge" value=""><br/>
@@ -172,16 +172,17 @@ if ($tdstylev!='') $tdstylev = " style=\"$tdstylev\"";
 		</div>
 		<div class="control-group">
 			<label class="control-label">
-				<a class="hasTooltip nolink" title="CSS code to be applied to the column that displays the form field <em>value</em>." data-toggle="tooltip" href="#">TD css value <span class="icon-info"></span></a><br/>
+				<a class="hasTooltip nolink" title="CSS code to be applied to the column that displays the form field <em>value</em> for e-mail and <em>body</em> for form-layout." data-toggle="tooltip" href="#">TD/DIV css value <span class="icon-info"></span></a><br/>
 			</label>
 			<div class="controls">
 				<input name="tdstylev" type="text" id="tdstylev" class="input-xlarge" value=""><br/>
 				<em>Example:</em> <strong>width:400px;font-size:12px;</strong>
+
 			</div>
 		</div>
 		<div class="control-group">
 			<label class="control-label">
-				<a class="hasTooltip nolink" title="CSS code to be applied to the whole table." data-toggle="tooltip" href="#">Full table CSS <span class="icon-info"></span></a><br/>
+				<a class="hasTooltip nolink" title="CSS code to be applied to the whole table for e-mail or container div for form-layout" data-toggle="tooltip" href="#">Full table / Container Div CSS <span class="icon-info"></span></a><br/>
 			</label>
 			<div class="controls">
 				<input name="tablecss" type="text" class="input-xlarge" id="tablecss" value=""><br/>

--- a/administrator/views/formselects/tmpl/default.php
+++ b/administrator/views/formselects/tmpl/default.php
@@ -62,6 +62,20 @@ if ($tdstylev!='') $tdstylev = " style=\"$tdstylev\"";
 			echo htmlspecialchars('  </tbody>').'<br/>'.htmlspecialchars('</table>').'<br/>';
 			echo '</pre>';
 			?>
+			<h3>Div Layout HTML :</h3>
+			<?php
+			echo '<pre class="prettyprint lang-html" style="padding:10px;">';
+			foreach ($this->items as $i => $item) :
+				echo htmlspecialchars('   ');
+				echo htmlspecialchars('<div '.$tablecss.'>').'<br/>';
+				echo htmlspecialchars('     ');
+				echo htmlspecialchars('<div'.$tdstylec.'>{'.$item->PropertyValue.':caption}<br />{'.$item->PropertyValue.':validation}</div>').'<br/>';
+				echo htmlspecialchars('     ');
+				echo htmlspecialchars('<div'.$tdstylev.'>{'.$item->PropertyValue.':body}</div>').'<br/>';
+				echo htmlspecialchars('   ');
+				echo htmlspecialchars('</div>').'<br/>';
+			endforeach;
+			echo '</pre>';
 			<h3>PHP code to add data to a database:</h3>
 			<?php
 			echo '<pre class="prettyprint lang-php" style="padding:10px;">';

--- a/administrator/views/formselects/tmpl/default.php
+++ b/administrator/views/formselects/tmpl/default.php
@@ -34,6 +34,12 @@ $tdstylec = $input->post->get('tdstylec','','HTML');
 if ($tdstylec!='') $tdstylec = " style=\"$tdstylec\"";
 $tdstylev = $input->post->get('tdstylev','','HTML');
 if ($tdstylev!='') $tdstylev = " style=\"$tdstylev\"";
+$containerdiv = $input->post->get('containerdiv','','HTML');
+if ($containerdiv!='') $containerdiv = " class=\"$containerdiv\"";
+$captiondiv = $input->post->get('captiondiv','','HTML');
+if ($captiondiv!='') $captiondiv = " class=\"$captiondiv\"";
+$bodydiv = $input->post->get('bodydiv','','HTML');
+if ($bodydiv!='') $bodydiv = " class=\"$bodydiv\"";
 ?>
 <form action="<?php echo JRoute::_('index.php?option=com_rsformhelper&view=formselects'); ?>" method="post" name="adminForm" id="adminForm" class="form-horizontal">
 	<div id="j-sidebar-container" class="span2">
@@ -62,20 +68,21 @@ if ($tdstylev!='') $tdstylev = " style=\"$tdstylev\"";
 			echo htmlspecialchars('  </tbody>').'<br/>'.htmlspecialchars('</table>').'<br/>';
 			echo '</pre>';
 			?>
-			<h3>Div Layout HTML :</h3>
+			<h3>Foundation Layout fields:</h3>
 			<?php
 			echo '<pre class="prettyprint lang-html" style="padding:10px;">';
 			foreach ($this->items as $i => $item) :
 				echo htmlspecialchars('   ');
-				echo htmlspecialchars('<div '.$tablecss.'>').'<br/>';
+				echo htmlspecialchars('<div'.$containerdiv.'>').'<br/>';
 				echo htmlspecialchars('     ');
-				echo htmlspecialchars('<div'.$tdstylec.'>{'.$item->PropertyValue.':caption}<br />{'.$item->PropertyValue.':validation}</div>').'<br/>';
+				echo htmlspecialchars('<div'.$captiondiv.'>{'.$item->PropertyValue.':caption}<br />{'.$item->PropertyValue.':validation}</div>').'<br/>';
 				echo htmlspecialchars('     ');
-				echo htmlspecialchars('<div'.$tdstylev.'>{'.$item->PropertyValue.':body}</div>').'<br/>';
+				echo htmlspecialchars('<div'.$bodydiv.'>{'.$item->PropertyValue.':body}</div>').'<br/>';
 				echo htmlspecialchars('   ');
 				echo htmlspecialchars('</div>').'<br/>';
 			endforeach;
 			echo '</pre>';
+			?>
 			<h3>PHP code to add data to a database:</h3>
 			<?php
 			echo '<pre class="prettyprint lang-php" style="padding:10px;">';
@@ -161,9 +168,9 @@ if ($tdstylev!='') $tdstylev = " style=\"$tdstylev\"";
 				</select>
 			</div>
 		</div>
-		<div class="control-group tdcsscaption">
+		<div class="control-group">
 			<label class="control-label">
-				<a class="hasTooltip nolink" title="CSS code to be applied to the column that displays the form field <em>caption</em>." data-toggle="tooltip" href="#">TD/DIV css caption <span class="icon-info"></span></a><br/>
+				<a class="hasTooltip nolink" title="CSS code to be applied to the column that displays the form field <em>caption</em>." data-toggle="tooltip" href="#">TD css caption <span class="icon-info"></span></a><br/>
 			</label>
 			<div class="controls">
 				<input name="tdstylec" type="text" id="tdstylec" class="input-xlarge" value=""><br/>
@@ -172,23 +179,51 @@ if ($tdstylev!='') $tdstylev = " style=\"$tdstylev\"";
 		</div>
 		<div class="control-group">
 			<label class="control-label">
-				<a class="hasTooltip nolink" title="CSS code to be applied to the column that displays the form field <em>value</em> for e-mail and <em>body</em> for form-layout." data-toggle="tooltip" href="#">TD/DIV css value <span class="icon-info"></span></a><br/>
+				<a class="hasTooltip nolink" title="CSS code to be applied to the column that displays the form field <em>value</em>." data-toggle="tooltip" href="#">TD css value <span class="icon-info"></span></a><br/>
 			</label>
 			<div class="controls">
 				<input name="tdstylev" type="text" id="tdstylev" class="input-xlarge" value=""><br/>
 				<em>Example:</em> <strong>width:400px;font-size:12px;</strong>
-
 			</div>
 		</div>
 		<div class="control-group">
 			<label class="control-label">
-				<a class="hasTooltip nolink" title="CSS code to be applied to the whole table for e-mail or container div for form-layout" data-toggle="tooltip" href="#">Full table / Container Div CSS <span class="icon-info"></span></a><br/>
+				<a class="hasTooltip nolink" title="CSS code to be applied to the whole table." data-toggle="tooltip" href="#">Full table CSS <span class="icon-info"></span></a><br/>
 			</label>
 			<div class="controls">
 				<input name="tablecss" type="text" class="input-xlarge" id="tablecss" value=""><br/>
 				<em>Example:</em> <strong>width:600px;border-collapse:collapse;</strong>
 			</div>
 		</div>
+<div class="control-group">
+			<label class="control-label">
+				<a class="hasTooltip nolink" title="CSS code to be applied to the container DIV." data-toggle="tooltip" href="#">DIV Class for containerdiv <span class="icon-info"></span></a><br/>
+			</label>
+			<div class="controls">
+				<input name="containerdiv" type="text" class="input-xlarge" id="containerdiv" value=""><br/>
+				<em>Example:</em> <strong>row</strong>
+			</div>
+		</div>
+<div class="control-group">
+			<label class="control-label">
+				<a class="hasTooltip nolink" title="Class to be applied to the column that displays the field <em>caption</em>." data-toggle="tooltip" href="#">DIV Class for caption <span class="icon-info"></span></a><br/>
+			</label>
+			<div class="controls">
+				<input name="captiondiv" type="text" id="captiondiv" class="input-xlarge" value=""><br/>
+				<em>Example:</em> <strong>small-12 medium-4 large-5 columns</strong>
+			</div>
+		</div>
+		<div class="control-group">
+			<label class="control-label">
+				<a class="hasTooltip nolink" title="Class to be applied to the column that displays the <em>body</em> for this field." data-toggle="tooltip" href="#">DIV Class for body <span class="icon-info"></span></a><br/>
+			</label>
+			<div class="controls">
+				<input name="bodydiv" type="text" id="bodydiv" class="input-xlarge" value=""><br/>
+				<em>Example:</em> <strong>small-12 medium-8 large-7 columns</strong>
+			</div>
+		</div>
+		
+
 		<div class="control-group">
 			<div class="controls">
 				<button type="submit" class="btn btn-success">Generate code</button>


### PR DESCRIPTION
This addition generates a very basic div-structure used for formlayout. Using the existing parameters for CSS the output is extended. This gives the user a way to quickly create a html layout for e.g. foundation, by simply adding the required css 'row' and 'small-, medium- and large- values'.
