### PR TITLE
Set no limit on number of items retrieved

### DIFF
--- a/administrator/models/formselects.php
+++ b/administrator/models/formselects.php
@@ -109,6 +109,8 @@ class RsformhelperModelFormselects extends JModelList {
 
 
 	public function getItems() {
+		// No limit, otherwise we only get the number of items set for pagination
+		$this->setState('list.limit', 0);
 		$items = parent::getItems();
 		
 		return $items;


### PR DESCRIPTION
This is needed because otherwise the output may only contain 20 fields for example but if you have a longer form, you miss the other fields.